### PR TITLE
Fix NaN using masks

### DIFF
--- a/executer_v2.py
+++ b/executer_v2.py
@@ -37,6 +37,7 @@ def process_region(folha):
         print(folha)
         # change config.ini
         configfile = os.path.join(folha_dir_name, f'{folha}.ini')
+
         with open(configfile, 'w') as f:
             config['io']['fname_limit'] = os.path.abspath(lim_name)
             config['io']['dir_out'] = os.path.abspath(folha_dir_name)


### PR DESCRIPTION
Store `NaN` masks based on `NaN` in the input features and target. The `NaN`s are dropped from the dataframe used to fit the models and reassigned for the final output.  